### PR TITLE
feat: Phase 2 - モダンな地図UIとインタラクティブ操作の実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Google Maps APIキーなどの機密情報は以下の方法で管理します�
 - Google Maps API key is required for geocoding functionality
 - The app focuses on UX/UI quality and smooth map interactions
 - **プロジェクトタスク管理**: 開発タスクは `.claude/plan/project-plan.md` を参照してください
+- **Pull Request作成時の注意**: このプロジェクトでは、すべてのPull Requestは `--draft` フラグを使用してドラフトとして作成してください
 
 ### プロジェクト固有の開発ガイドライン
 

--- a/src/app/core/services/coordinate-transform.service.spec.ts
+++ b/src/app/core/services/coordinate-transform.service.spec.ts
@@ -1,0 +1,87 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { CoordinateTransformService } from './coordinate-transform.service';
+
+describe('CoordinateTransformService', () => {
+  let service: CoordinateTransformService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()]
+    });
+    service = TestBed.inject(CoordinateTransformService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('latLngToSvg', () => {
+    it('should convert Tokyo coordinates to SVG point', () => {
+      const tokyo = { lat: 35.6762, lng: 139.6503 };
+      const svgPoint = service.latLngToSvg(tokyo);
+      
+      expect(svgPoint.x).toBeGreaterThan(0);
+      expect(svgPoint.x).toBeLessThan(1000);
+      expect(svgPoint.y).toBeGreaterThan(0);
+      expect(svgPoint.y).toBeLessThan(1000);
+    });
+
+    it('should convert Sapporo coordinates to SVG point', () => {
+      const sapporo = { lat: 43.0642, lng: 141.3469 };
+      const svgPoint = service.latLngToSvg(sapporo);
+      
+      // 札幌は北にあるのでy座標は小さくなるはず
+      expect(svgPoint.y).toBeLessThan(500);
+    });
+
+    it('should convert Okinawa coordinates to SVG point', () => {
+      const okinawa = { lat: 26.2124, lng: 127.6809 };
+      const svgPoint = service.latLngToSvg(okinawa);
+      
+      // 沖縄は南にあるのでy座標は大きくなるはず
+      expect(svgPoint.y).toBeGreaterThan(500);
+    });
+  });
+
+  describe('svgToLatLng', () => {
+    it('should convert SVG point back to lat/lng', () => {
+      const originalLatLng = { lat: 35.6762, lng: 139.6503 };
+      const svgPoint = service.latLngToSvg(originalLatLng);
+      const convertedLatLng = service.svgToLatLng(svgPoint);
+      
+      expect(convertedLatLng.lat).toBeCloseTo(originalLatLng.lat, 4);
+      expect(convertedLatLng.lng).toBeCloseTo(originalLatLng.lng, 4);
+    });
+  });
+
+  describe('isInJapanBounds', () => {
+    it('should return true for locations in Japan', () => {
+      expect(service.isInJapanBounds({ lat: 35.6762, lng: 139.6503 })).toBe(true); // Tokyo
+      expect(service.isInJapanBounds({ lat: 43.0642, lng: 141.3469 })).toBe(true); // Sapporo
+      expect(service.isInJapanBounds({ lat: 34.6937, lng: 135.5023 })).toBe(true); // Osaka
+    });
+
+    it('should return false for locations outside Japan', () => {
+      expect(service.isInJapanBounds({ lat: 37.7749, lng: -122.4194 })).toBe(false); // San Francisco
+      expect(service.isInJapanBounds({ lat: 51.5074, lng: -0.1278 })).toBe(false); // London
+      expect(service.isInJapanBounds({ lat: -33.8688, lng: 151.2093 })).toBe(false); // Sydney
+    });
+  });
+
+  describe('updateSvgViewBox', () => {
+    it('should update SVG viewBox', () => {
+      const newViewBox = { x: 100, y: 100, width: 800, height: 800 };
+      service.updateSvgViewBox(newViewBox);
+      
+      // 新しいviewBoxで変換が正しく動作することを確認
+      const tokyo = { lat: 35.6762, lng: 139.6503 };
+      const svgPoint = service.latLngToSvg(tokyo);
+      
+      expect(svgPoint.x).toBeGreaterThan(100);
+      expect(svgPoint.x).toBeLessThan(900);
+      expect(svgPoint.y).toBeGreaterThan(100);
+      expect(svgPoint.y).toBeLessThan(900);
+    });
+  });
+});

--- a/src/app/core/services/coordinate-transform.service.ts
+++ b/src/app/core/services/coordinate-transform.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@angular/core';
+
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export interface SvgPoint {
+  x: number;
+  y: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CoordinateTransformService {
+  // 日本の地理的境界
+  private readonly JAPAN_BOUNDS = {
+    north: 45.5572,  // 北海道最北端
+    south: 20.4229,  // 沖縄最南端
+    east: 153.9868,  // 東端
+    west: 122.9333   // 西端
+  };
+
+  // SVGのviewBox（実際のSVGファイルに合わせて調整が必要）
+  private readonly SVG_VIEWBOX = {
+    x: 0,
+    y: 0,
+    width: 1000,
+    height: 1000
+  };
+
+  constructor() {}
+
+  /**
+   * 緯度経度をSVG座標に変換
+   */
+  latLngToSvg(latLng: LatLng): SvgPoint {
+    const { lat, lng } = latLng;
+    
+    // 緯度経度を0-1の範囲に正規化
+    const normalizedX = (lng - this.JAPAN_BOUNDS.west) / 
+                       (this.JAPAN_BOUNDS.east - this.JAPAN_BOUNDS.west);
+    const normalizedY = 1 - (lat - this.JAPAN_BOUNDS.south) / 
+                       (this.JAPAN_BOUNDS.north - this.JAPAN_BOUNDS.south);
+    
+    // SVG座標に変換
+    const svgX = this.SVG_VIEWBOX.x + normalizedX * this.SVG_VIEWBOX.width;
+    const svgY = this.SVG_VIEWBOX.y + normalizedY * this.SVG_VIEWBOX.height;
+    
+    return { x: svgX, y: svgY };
+  }
+
+  /**
+   * SVG座標を緯度経度に変換
+   */
+  svgToLatLng(point: SvgPoint): LatLng {
+    const { x, y } = point;
+    
+    // SVG座標を0-1の範囲に正規化
+    const normalizedX = (x - this.SVG_VIEWBOX.x) / this.SVG_VIEWBOX.width;
+    const normalizedY = (y - this.SVG_VIEWBOX.y) / this.SVG_VIEWBOX.height;
+    
+    // 緯度経度に変換
+    const lng = this.JAPAN_BOUNDS.west + 
+               normalizedX * (this.JAPAN_BOUNDS.east - this.JAPAN_BOUNDS.west);
+    const lat = this.JAPAN_BOUNDS.south + 
+               (1 - normalizedY) * (this.JAPAN_BOUNDS.north - this.JAPAN_BOUNDS.south);
+    
+    return { lat, lng };
+  }
+
+  /**
+   * 指定された緯度経度が日本の境界内にあるかチェック
+   */
+  isInJapanBounds(latLng: LatLng): boolean {
+    const { lat, lng } = latLng;
+    return lat >= this.JAPAN_BOUNDS.south && lat <= this.JAPAN_BOUNDS.north &&
+           lng >= this.JAPAN_BOUNDS.west && lng <= this.JAPAN_BOUNDS.east;
+  }
+
+  /**
+   * SVGファイルのviewBoxを更新（SVGロード時に呼び出す）
+   */
+  updateSvgViewBox(viewBox: { x: number; y: number; width: number; height: number }): void {
+    this.SVG_VIEWBOX.x = viewBox.x;
+    this.SVG_VIEWBOX.y = viewBox.y;
+    this.SVG_VIEWBOX.width = viewBox.width;
+    this.SVG_VIEWBOX.height = viewBox.height;
+  }
+}

--- a/src/app/core/services/marker-clustering.service.ts
+++ b/src/app/core/services/marker-clustering.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@angular/core';
+import { Cafe } from '../models/cafe.model';
+import { CoordinateTransformService, SvgPoint } from './coordinate-transform.service';
+
+export interface CafeCluster {
+  id: string;
+  cafes: Cafe[];
+  center: SvgPoint;
+  bounds: {
+    minX: number;
+    maxX: number;
+    minY: number;
+    maxY: number;
+  };
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MarkerClusteringService {
+  constructor(private coordinateTransform: CoordinateTransformService) {}
+
+  /**
+   * カフェをクラスタリング
+   * @param cafes カフェのリスト
+   * @param zoomLevel 現在のズームレベル
+   * @param clusterRadius クラスタリング半径（SVG座標系）
+   */
+  clusterCafes(cafes: Cafe[], zoomLevel: number, clusterRadius: number = 50): CafeCluster[] {
+    // ズームレベルに応じてクラスタリング半径を調整
+    const adjustedRadius = clusterRadius / Math.pow(zoomLevel, 0.5);
+    
+    const clusters: CafeCluster[] = [];
+    const processedCafes = new Set<string>();
+
+    cafes.forEach(cafe => {
+      if (processedCafes.has(cafe.id.toString()) || !cafe.lat || !cafe.lng) {
+        return;
+      }
+
+      // 新しいクラスタを作成
+      const cafePosition = this.coordinateTransform.latLngToSvg({
+        lat: cafe.lat,
+        lng: cafe.lng
+      });
+
+      const cluster: CafeCluster = {
+        id: `cluster-${clusters.length}`,
+        cafes: [cafe],
+        center: cafePosition,
+        bounds: {
+          minX: cafePosition.x,
+          maxX: cafePosition.x,
+          minY: cafePosition.y,
+          maxY: cafePosition.y
+        }
+      };
+
+      processedCafes.add(cafe.id.toString());
+
+      // 近くのカフェをクラスタに追加
+      cafes.forEach(otherCafe => {
+        if (processedCafes.has(otherCafe.id.toString()) || 
+            !otherCafe.lat || !otherCafe.lng ||
+            cafe.id === otherCafe.id) {
+          return;
+        }
+
+        const otherPosition = this.coordinateTransform.latLngToSvg({
+          lat: otherCafe.lat,
+          lng: otherCafe.lng
+        });
+
+        const distance = this.calculateDistance(cafePosition, otherPosition);
+
+        if (distance <= adjustedRadius) {
+          cluster.cafes.push(otherCafe);
+          processedCafes.add(otherCafe.id.toString());
+
+          // クラスタの境界を更新
+          cluster.bounds.minX = Math.min(cluster.bounds.minX, otherPosition.x);
+          cluster.bounds.maxX = Math.max(cluster.bounds.maxX, otherPosition.x);
+          cluster.bounds.minY = Math.min(cluster.bounds.minY, otherPosition.y);
+          cluster.bounds.maxY = Math.max(cluster.bounds.maxY, otherPosition.y);
+        }
+      });
+
+      // クラスタの中心を再計算
+      if (cluster.cafes.length > 1) {
+        cluster.center = this.calculateClusterCenter(cluster);
+      }
+
+      clusters.push(cluster);
+    });
+
+    return clusters;
+  }
+
+  /**
+   * 2点間の距離を計算
+   */
+  private calculateDistance(point1: SvgPoint, point2: SvgPoint): number {
+    const dx = point1.x - point2.x;
+    const dy = point1.y - point2.y;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
+  /**
+   * クラスタの中心点を計算
+   */
+  private calculateClusterCenter(cluster: CafeCluster): SvgPoint {
+    let sumX = 0;
+    let sumY = 0;
+    let count = 0;
+
+    cluster.cafes.forEach(cafe => {
+      if (cafe.lat && cafe.lng) {
+        const position = this.coordinateTransform.latLngToSvg({
+          lat: cafe.lat,
+          lng: cafe.lng
+        });
+        sumX += position.x;
+        sumY += position.y;
+        count++;
+      }
+    });
+
+    return {
+      x: sumX / count,
+      y: sumY / count
+    };
+  }
+
+  /**
+   * ズームレベルに応じてクラスタリングを使用するかどうかを判定
+   */
+  shouldUseClustering(zoomLevel: number): boolean {
+    return zoomLevel < 2.5;
+  }
+}

--- a/src/app/features/map/map-view/map-view.css
+++ b/src/app/features/map/map-view/map-view.css
@@ -104,10 +104,12 @@
 }
 
 .japan-map {
-  width: 100%;
-  height: 100%;
+  width: 800px;
+  height: 800px;
+  margin-left: -400px;
+  margin-top: -400px;
   filter: drop-shadow(0 10px 30px rgba(0, 0, 0, 0.1));
-  pointer-events: none;
+  pointer-events: all;
   -webkit-user-drag: none;
   user-select: none;
   -webkit-user-select: none;
@@ -236,7 +238,147 @@
   background: rgba(0, 0, 0, 0.08);
 }
 
-/* ����� */
+/* カフェマーカー */
+.cafe-markers {
+  pointer-events: all;
+}
+
+.cafe-marker {
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cafe-marker:hover {
+  transform: scale(1.2);
+}
+
+.cafe-marker.selected {
+  transform: scale(1.3);
+}
+
+.cafe-marker circle {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2));
+}
+
+/* カフェクラスター */
+.cafe-cluster {
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.cafe-cluster:hover {
+  transform: scale(1.1);
+}
+
+.cafe-cluster circle {
+  filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.3));
+}
+
+.cafe-cluster text {
+  pointer-events: none;
+  user-select: none;
+}
+
+/* カフェポップアップ */
+.cafe-popup {
+  position: absolute;
+  background: white;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  z-index: 70;
+  min-width: 250px;
+  max-width: 300px;
+  transform: translate(-50%, -100%) translateY(-20px);
+  animation: popupFadeIn 0.2s ease-out;
+}
+
+@keyframes popupFadeIn {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -100%) translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -100%) translateY(-20px);
+  }
+}
+
+.popup-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s;
+}
+
+.popup-close:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.popup-close svg {
+  stroke: currentColor;
+  stroke-width: 2;
+}
+
+.popup-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  padding-right: 20px;
+  color: #1a1a1a;
+}
+
+.popup-content {
+  margin: 0 0 12px 0;
+}
+
+.popup-address {
+  font-size: 14px;
+  color: #666;
+  margin: 0 0 8px 0;
+}
+
+.popup-rating {
+  margin: 8px 0;
+}
+
+.popup-rating .stars {
+  font-size: 16px;
+  color: #FFB800;
+  letter-spacing: 2px;
+}
+
+.popup-notes {
+  font-size: 14px;
+  color: #333;
+  margin: 8px 0;
+  line-height: 1.5;
+}
+
+.popup-link {
+  display: inline-block;
+  font-size: 14px;
+  color: #007AFF;
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s;
+}
+
+.popup-link:hover {
+  color: #0051D5;
+  text-decoration: underline;
+}
+
+/* ボトムシート */
 .bottom-sheet {
   position: absolute;
   bottom: 0;
@@ -248,6 +390,8 @@
   z-index: 60;
   padding-bottom: env(safe-area-inset-bottom, 0);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  max-height: 40vh;
+  overflow: hidden;
 }
 
 .sheet-handle {
@@ -272,6 +416,42 @@
 
 .cafe-list {
   min-height: 120px;
+  max-height: calc(40vh - 120px);
+  overflow-y: auto;
+}
+
+.cafe-item {
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: #f8f9fa;
+  margin-bottom: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cafe-item:hover {
+  background: #e9ecef;
+  transform: translateX(4px);
+}
+
+.cafe-item h4 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+  color: #1a1a1a;
+}
+
+.cafe-item p {
+  font-size: 14px;
+  color: #666;
+  margin: 0;
+}
+
+.cafe-item .rating {
+  font-size: 14px;
+  color: #FFB800;
+  margin-top: 4px;
+  display: inline-block;
 }
 
 .empty-state {
@@ -306,6 +486,74 @@
   
   .sheet-content {
     padding: 0 16px 16px;
+  }
+  
+  .bottom-sheet {
+    max-height: 35vh;
+  }
+  
+  .cafe-popup {
+    min-width: 200px;
+    max-width: 250px;
+    font-size: 14px;
+  }
+  
+  .popup-title {
+    font-size: 16px;
+  }
+}
+
+/* タブレット向け */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .floating-controls {
+    right: 24px;
+    bottom: 200px;
+  }
+  
+  .bottom-sheet {
+    max-width: 600px;
+    margin: 0 auto;
+  }
+  
+  .cafe-popup {
+    min-width: 280px;
+    max-width: 350px;
+  }
+}
+
+/* デスクトップ向け */
+@media (min-width: 1025px) {
+  .map-container {
+    display: flex;
+  }
+  
+  .bottom-sheet {
+    position: fixed;
+    left: 0;
+    top: 70px;
+    bottom: 0;
+    right: auto;
+    width: 360px;
+    border-radius: 0;
+    max-height: none;
+  }
+  
+  .sheet-handle {
+    display: none;
+  }
+  
+  .cafe-list {
+    max-height: calc(100vh - 200px);
+  }
+  
+  .floating-controls {
+    right: 30px;
+    bottom: 30px;
+  }
+  
+  .cafe-popup {
+    min-width: 320px;
+    max-width: 400px;
   }
 }
 

--- a/src/app/features/map/map-view/map-view.html
+++ b/src/app/features/map/map-view/map-view.html
@@ -33,9 +33,50 @@
     <div class="map-content" 
          [style.transform]="'translate(' + panX() + 'px, ' + panY() + 'px) scale(' + zoomLevel() + ')'">
       <!-- SVG地図 -->
-      <div class="japan-map-wrapper">
-        <img class="japan-map" src="assets/japan-map.svg" alt="日本地図" draggable="false" />
-      </div>
+      <svg class="japan-map" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg">
+        <g [innerHTML]="mapSvgContent()"></g>
+        
+        <!-- カフェマーカー/クラスター -->
+        <g class="cafe-markers">
+          @if (useClustering()) {
+            <!-- クラスター表示 -->
+            @for (cluster of clusters(); track cluster.id) {
+              <g class="cafe-cluster"
+                 [attr.transform]="'translate(' + cluster.center.x + ',' + cluster.center.y + ')'"
+                 (click)="onClusterClick(cluster, $event)">
+                @if (cluster.cafes.length > 1) {
+                  <!-- 複数カフェのクラスター -->
+                  <circle r="20" fill="#8B4513" stroke="white" stroke-width="3" opacity="0.9"/>
+                  <text y="1" text-anchor="middle" fill="white" font-size="14" font-weight="bold">{{ cluster.cafes.length }}</text>
+                } @else {
+                  <!-- 単一カフェ -->
+                  <g class="cafe-marker" [class.selected]="selectedCafe()?.id === cluster.cafes[0].id">
+                    <circle r="8" fill="#8B4513" stroke="white" stroke-width="2"/>
+                    <path d="M 0,-8 L -3,-3 L -2,-3 L -2,0 L 2,0 L 2,-3 L 3,-3 Z" 
+                          fill="white" 
+                          transform="scale(0.6)"/>
+                  </g>
+                }
+              </g>
+            }
+          } @else {
+            <!-- 通常のマーカー表示 -->
+            @for (cafe of cafes(); track cafe.id) {
+              @if (getCafeSvgPosition(cafe); as position) {
+                <g class="cafe-marker"
+                   [attr.transform]="'translate(' + position.x + ',' + position.y + ')'"
+                   (click)="onCafeClick(cafe, $event)"
+                   [class.selected]="selectedCafe()?.id === cafe.id">
+                  <circle r="8" fill="#8B4513" stroke="white" stroke-width="2"/>
+                  <path d="M 0,-8 L -3,-3 L -2,-3 L -2,0 L 2,0 L 2,-3 L 3,-3 Z" 
+                        fill="white" 
+                        transform="scale(0.6)"/>
+                </g>
+              }
+            }
+          }
+        </g>
+      </svg>
     </div>
   </div>
 
@@ -64,22 +105,61 @@
     </div>
   </div>
 
+  <!-- カフェ詳細ポップアップ -->
+  @if (selectedCafe(); as cafe) {
+    <div class="cafe-popup" 
+         [style.left.px]="getCafeSvgPosition(cafe)?.x"
+         [style.top.px]="getCafeSvgPosition(cafe)?.y"
+         (click)="$event.stopPropagation()">
+      <button class="popup-close" (click)="closePopup()" aria-label="Close">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M12.5 3.5L3.5 12.5M3.5 3.5l9 9"/>
+        </svg>
+      </button>
+      <h3 class="popup-title">{{ cafe.name }}</h3>
+      <div class="popup-content">
+        <p class="popup-address">{{ cafe.address }}</p>
+        @if (cafe.rating) {
+          <div class="popup-rating">
+            <span class="stars">{{ '★'.repeat(cafe.rating) + '☆'.repeat(5 - cafe.rating) }}</span>
+          </div>
+        }
+        @if (cafe.memo) {
+          <p class="popup-notes">{{ cafe.memo }}</p>
+        }
+      </div>
+      <a [href]="'/cafes/' + cafe.id" class="popup-link">詳細を見る →</a>
+    </div>
+  }
+
   <!-- ボトムシート風のカフェリスト -->
   <div class="bottom-sheet">
     <div class="sheet-handle"></div>
     <div class="sheet-content">
-      <h2 class="sheet-title">近くのカフェ</h2>
+      <h2 class="sheet-title">登録カフェ ({{ cafes().length }}件)</h2>
       <div class="cafe-list">
-        <div class="empty-state">
-          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" opacity="0.3">
-            <path d="M18 8h1a4 4 0 0 1 0 8h-1"/>
-            <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/>
-            <line x1="6" y1="1" x2="6" y2="4"/>
-            <line x1="10" y1="1" x2="10" y2="4"/>
-            <line x1="14" y1="1" x2="14" y2="4"/>
-          </svg>
-          <p>まだカフェが登録されていません</p>
-        </div>
+        @if (cafes().length === 0) {
+          <div class="empty-state">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" opacity="0.3">
+              <path d="M18 8h1a4 4 0 0 1 0 8h-1"/>
+              <path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/>
+              <line x1="6" y1="1" x2="6" y2="4"/>
+              <line x1="10" y1="1" x2="10" y2="4"/>
+              <line x1="14" y1="1" x2="14" y2="4"/>
+            </svg>
+            <p>まだカフェが登録されていません</p>
+          </div>
+        } @else {
+          @for (cafe of cafes(); track cafe.id) {
+            <div class="cafe-item" (click)="onCafeClick(cafe, $event)">
+              <h4>{{ cafe.name }}</h4>
+              <p>{{ cafe.address }}</p>
+              @if (cafe.rating) {
+                <span class="rating">{{ '★'.repeat(cafe.rating) }}</span>
+              }
+            </div>
+          }
+        }
       </div>
     </div>
   </div>

--- a/src/app/features/map/map-view/map-view.spec.ts
+++ b/src/app/features/map/map-view/map-view.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { MapViewComponent } from './map-view';
 
 describe('MapViewComponent', () => {
@@ -11,6 +12,7 @@ describe('MapViewComponent', () => {
     await TestBed.configureTestingModule({
       imports: [MapViewComponent],
       providers: [
+        provideZonelessChangeDetection(),
         provideHttpClient(),
         provideHttpClientTesting()
       ]

--- a/src/app/features/map/map-view/map-view.ts
+++ b/src/app/features/map/map-view/map-view.ts
@@ -1,7 +1,11 @@
-import { Component, signal, OnInit, inject } from '@angular/core';
+import { Component, signal, OnInit, inject, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { CoordinateTransformService } from '../../../core/services/coordinate-transform.service';
+import { CafeStorageService } from '../../../core/services/cafe-storage.service';
+import { MarkerClusteringService, CafeCluster } from '../../../core/services/marker-clustering.service';
+import { Cafe } from '../../../core/models/cafe.model';
 
 @Component({
   selector: 'app-map-view',
@@ -13,6 +17,9 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 export class MapViewComponent implements OnInit {
   private http = inject(HttpClient);
   private sanitizer = inject(DomSanitizer);
+  private coordinateTransform = inject(CoordinateTransformService);
+  private cafeStorage = inject(CafeStorageService);
+  private markerClustering = inject(MarkerClusteringService);
   
   zoomLevel = signal(1);
   panX = signal(0);
@@ -20,6 +27,15 @@ export class MapViewComponent implements OnInit {
   
   selectedPrefecture = signal<string | null>(null);
   mapSvgContent = signal<SafeHtml>('');
+  cafes = signal<Cafe[]>([]);
+  selectedCafe = signal<Cafe | null>(null);
+  clusters = signal<CafeCluster[]>([]);
+  
+  // クラスタリングを使用するかどうか
+  useClustering = computed(() => this.markerClustering.shouldUseClustering(this.zoomLevel()));
+  
+  // SVGのviewBox情報
+  svgViewBox = signal<{ x: number; y: number; width: number; height: number } | null>(null);
   
   Math = Math;
   
@@ -30,8 +46,35 @@ export class MapViewComponent implements OnInit {
   private dragStartPanX = 0;
   private dragStartPanY = 0;
   
+  // ピンチズーム状態管理
+  private isPinching = false;
+  private lastPinchDistance = 0;
+  
+  // ダブルタップ検出
+  private lastTapTime = 0;
+  private lastTapX = 0;
+  private lastTapY = 0;
+  
   ngOnInit() {
     this.loadMapData();
+    this.loadCafes();
+  }
+  
+  private async loadCafes() {
+    try {
+      const cafes = await this.cafeStorage.getAllCafes();
+      this.cafes.set(cafes);
+      this.updateClusters();
+    } catch (error) {
+      console.error('カフェデータの読み込みに失敗:', error);
+    }
+  }
+  
+  // クラスタを更新
+  private updateClusters() {
+    const cafes = this.cafes();
+    const clusters = this.markerClustering.clusterCafes(cafes, this.zoomLevel());
+    this.clusters.set(clusters);
   }
   
   // マウスダウンイベント
@@ -83,35 +126,108 @@ export class MapViewComponent implements OnInit {
     this.panX.set(mouseX - (mouseX - this.panX()) * scaleDiff);
     this.panY.set(mouseY - (mouseY - this.panY()) * scaleDiff);
     this.zoomLevel.set(newZoom);
+    this.updateClusters();
   }
   
   // タッチ開始イベント
   onTouchStart(event: TouchEvent) {
     if (event.touches.length === 1) {
+      // ダブルタップの検出
+      const now = Date.now();
+      const x = event.touches[0].clientX;
+      const y = event.touches[0].clientY;
+      
+      if (now - this.lastTapTime < 300 && 
+          Math.abs(x - this.lastTapX) < 30 && 
+          Math.abs(y - this.lastTapY) < 30) {
+        // ダブルタップズーム
+        this.onDoubleTap(x, y);
+        event.preventDefault();
+        return;
+      }
+      
+      this.lastTapTime = now;
+      this.lastTapX = x;
+      this.lastTapY = y;
+      
       this.isDragging = true;
-      this.dragStartX = event.touches[0].clientX;
-      this.dragStartY = event.touches[0].clientY;
+      this.dragStartX = x;
+      this.dragStartY = y;
       this.dragStartPanX = this.panX();
       this.dragStartPanY = this.panY();
+      event.preventDefault();
+    } else if (event.touches.length === 2) {
+      // ピンチズーム開始
+      this.isPinching = true;
+      this.lastPinchDistance = this.getPinchDistance(event.touches);
       event.preventDefault();
     }
   }
   
   // タッチ移動イベント
   onTouchMove(event: TouchEvent) {
-    if (!this.isDragging || event.touches.length !== 1) return;
-    
-    const deltaX = event.touches[0].clientX - this.dragStartX;
-    const deltaY = event.touches[0].clientY - this.dragStartY;
-    
-    this.panX.set(this.dragStartPanX + deltaX);
-    this.panY.set(this.dragStartPanY + deltaY);
-    event.preventDefault();
+    if (event.touches.length === 1 && this.isDragging) {
+      const deltaX = event.touches[0].clientX - this.dragStartX;
+      const deltaY = event.touches[0].clientY - this.dragStartY;
+      
+      this.panX.set(this.dragStartPanX + deltaX);
+      this.panY.set(this.dragStartPanY + deltaY);
+      event.preventDefault();
+    } else if (event.touches.length === 2 && this.isPinching) {
+      // ピンチズーム
+      const currentDistance = this.getPinchDistance(event.touches);
+      const scale = currentDistance / this.lastPinchDistance;
+      
+      const newZoom = Math.max(0.5, Math.min(5, this.zoomLevel() * scale));
+      
+      // ピンチ中心を計算
+      const centerX = (event.touches[0].clientX + event.touches[1].clientX) / 2;
+      const centerY = (event.touches[0].clientY + event.touches[1].clientY) / 2;
+      
+      const rect = (event.target as HTMLElement).getBoundingClientRect();
+      const relativeX = centerX - rect.left - rect.width / 2;
+      const relativeY = centerY - rect.top - rect.height / 2;
+      
+      const scaleDiff = newZoom / this.zoomLevel();
+      
+      this.panX.set(relativeX - (relativeX - this.panX()) * scaleDiff);
+      this.panY.set(relativeY - (relativeY - this.panY()) * scaleDiff);
+      this.zoomLevel.set(newZoom);
+      this.updateClusters();
+      
+      this.lastPinchDistance = currentDistance;
+      event.preventDefault();
+    }
   }
   
   // タッチ終了イベント
   onTouchEnd() {
     this.isDragging = false;
+    this.isPinching = false;
+  }
+  
+  // ピンチ距離の計算
+  private getPinchDistance(touches: TouchList): number {
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+  
+  // ダブルタップズーム
+  private onDoubleTap(x: number, y: number) {
+    const currentZoom = this.zoomLevel();
+    const newZoom = currentZoom < 2 ? Math.min(currentZoom * 2, 3) : 1;
+    
+    const rect = (document.querySelector('.map-viewport') as HTMLElement).getBoundingClientRect();
+    const relativeX = x - rect.left - rect.width / 2;
+    const relativeY = y - rect.top - rect.height / 2;
+    
+    const scaleDiff = newZoom / currentZoom;
+    
+    this.panX.set(relativeX - (relativeX - this.panX()) * scaleDiff);
+    this.panY.set(relativeY - (relativeY - this.panY()) * scaleDiff);
+    this.zoomLevel.set(newZoom);
+    this.updateClusters();
   }
   
   private loadMapData() {
@@ -124,6 +240,15 @@ export class MapViewComponent implements OnInit {
           const svgElement = svgDoc.querySelector('svg');
           
           if (svgElement) {
+            // ViewBoxを取得して座標変換サービスに設定
+            const viewBoxAttr = svgElement.getAttribute('viewBox');
+            if (viewBoxAttr) {
+              const [x, y, width, height] = viewBoxAttr.split(' ').map(Number);
+              const viewBox = { x, y, width, height };
+              this.svgViewBox.set(viewBox);
+              this.coordinateTransform.updateSvgViewBox(viewBox);
+            }
+            
             const innerContent = svgElement.innerHTML;
             console.log('SVG内部コンテンツ:', innerContent.substring(0, 200));
             const safeHtml = this.sanitizer.bypassSecurityTrustHtml(innerContent);
@@ -136,5 +261,50 @@ export class MapViewComponent implements OnInit {
           console.error('SVGの読み込みに失敗:', error);
         }
       });
+  }
+  
+  // カフェマーカーのクリックイベント
+  onCafeClick(cafe: Cafe, event: MouseEvent) {
+    event.stopPropagation();
+    this.selectedCafe.set(cafe);
+  }
+  
+  // ポップアップを閉じる
+  closePopup() {
+    this.selectedCafe.set(null);
+  }
+  
+  // カフェの位置をSVG座標に変換
+  getCafeSvgPosition(cafe: Cafe) {
+    if (!cafe.lat || !cafe.lng) {
+      return null;
+    }
+    return this.coordinateTransform.latLngToSvg({
+      lat: cafe.lat,
+      lng: cafe.lng
+    });
+  }
+  
+  // クラスタのクリックイベント
+  onClusterClick(cluster: CafeCluster, event: MouseEvent) {
+    event.stopPropagation();
+    
+    // クラスタが1つのカフェのみの場合は直接ポップアップを表示
+    if (cluster.cafes.length === 1) {
+      this.selectedCafe.set(cluster.cafes[0]);
+    } else {
+      // 複数のカフェがある場合はズームイン
+      const newZoom = Math.min(this.zoomLevel() * 1.5, 5);
+      
+      // クラスタ中心にパン
+      const rect = (document.querySelector('.map-viewport') as HTMLElement).getBoundingClientRect();
+      const centerX = rect.width / 2;
+      const centerY = rect.height / 2;
+      
+      this.panX.set(centerX - cluster.center.x * newZoom);
+      this.panY.set(centerY - cluster.center.y * newZoom);
+      this.zoomLevel.set(newZoom);
+      this.updateClusters();
+    }
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  googleMapsApiKey: 'YOUR_PRODUCTION_GOOGLE_MAPS_API_KEY_HERE' // モックキー
+  googleMapsApiKey: ''
 };


### PR DESCRIPTION
## 概要
Phase 2の全機能を実装しました。日本地図上にカフェ情報をマッピングし、Google Maps風のインタラクティブな操作を可能にしました。

## 実装内容
### 🗺️ 地図基盤
- SVG日本地図の表示
- 座標変換システム（緯度経度 ↔ SVG座標）
- カフェデータとの連携

### 📍 マーカー機能
- カフェ位置にマーカー表示
- クリックでポップアップ表示（店名、住所、評価、メモ）
- マーカークラスタリング（ズームレベルに応じて自動グループ化）

### 🎮 インタラクション
- ドラッグでのパン操作
- マウスホイール/ピンチでのズーム
- ダブルタップでのズーム
- ズームコントロールボタン

### 📱 レスポンシブ対応
- モバイル：ボトムシート式のカフェリスト
- タブレット：中央配置のボトムシート
- デスクトップ：サイドパネル表示

## テスト結果
- ✅ 全テスト合格（63 tests passed）
- ✅ ビルド成功

## 技術的詳細
- Angular 20 standalone components
- Zoneless change detection
- SVGベースのマップレンダリング
- Dexie.jsによるIndexedDBデータ管理

## 今後の改善点
- CSSファイルサイズの最適化（現在6.72KB、予算4KB）
- 実際のSVG地図データとの座標調整
- パフォーマンスチューニング

🤖 Generated with [Claude Code](https://claude.ai/code)